### PR TITLE
Add buffering capability to demo apps

### DIFF
--- a/app/ambient-encounter-demo/demo.js
+++ b/app/ambient-encounter-demo/demo.js
@@ -1,4 +1,5 @@
 // Ambient encounter demo implementation
+import { BufferedAudioStream } from '../shared/bufferAudioStream.js';
 import { getOrRefetchUserAccessToken, CORE_API_BASE_URL } from '../shared/authentication.js';
 import {
     disableElementById,
@@ -16,6 +17,7 @@ import {
 
 let generatedNote = undefined;
 let websocket;
+let bufferAudioStream;
 let transcriptItems = {};
 let transcriptSeqId = 0;
 let noteSectionsCustomization = {};
@@ -123,7 +125,7 @@ const initializeTranscriptConnection = async () => {
             const data = JSON.parse(mes.data);
 
             if (data.type === "AUDIO_CHUNK_ACK") {
-                // This is where you'd remove audio chunks from your buffer
+                bufferAudioStream.handlePacketAck(data);
             } else if (data.type === "TRANSCRIPT_ITEM") {
                 insertTranscriptItem(data);
             } else if (data.type === "ERROR_MESSAGE") {
@@ -183,32 +185,39 @@ const startRecording = async () => {
         throw new Error("Websocket did not open");
     }
 
-    if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
-        const pcmWorker = await initializeMediaStream((audioAsBase64String) => {
-            return JSON.stringify({
-                type: "AUDIO_CHUNK",
-                payload: audioAsBase64String,
-                stream_id: "stream1",
-                seq_id: transcriptSeqId++,
-            });
-        }, websocket);
-
-        const config = {
-            type: "CONFIG",
-            encoding: "PCM_S16LE",
-            sample_rate: 16000,
-            speech_locales: [getFirstTranscriptLocale(), getSecondTranscriptLocale()],
-            streams: [
-                { id: "stream1", speaker_type: "unspecified" },
-            ],
-            enable_audio_chunk_ack: true,
-        };
-        websocket.send(JSON.stringify(config));
-
-        pcmWorker.port.start();
-    } else {
+    if (!navigator.mediaDevices?.getUserMedia) {
         console.error("Microphone audio stream is not accessible on this browser");
+        return;
     }
+
+    bufferAudioStream = new BufferedAudioStream({
+        serializeAudioPacket: (data) => JSON.stringify(data),
+        websocket,
+    });
+
+    const pcmWorker = await initializeMediaStream((audioAsBase64String) => {
+        const audioPacket = {
+            type: "AUDIO_CHUNK",
+            payload: audioAsBase64String,
+            stream_id: "stream1",
+            seq_id: transcriptSeqId++,
+        };
+        bufferAudioStream.sendAndBuffer(audioPacket);
+    });
+
+    const configPacket = {
+        type: "CONFIG",
+        encoding: "PCM_S16LE",
+        sample_rate: 16000,
+        speech_locales: [getFirstTranscriptLocale(), getSecondTranscriptLocale()],
+        streams: [
+            { id: "stream1", speaker_type: "unspecified" },
+        ],
+        enable_audio_chunk_ack: true,
+    };
+    websocket.send(JSON.stringify(configPacket));
+
+    pcmWorker.port.start();
 };
 
 // Note generation

--- a/app/dictated-note-demo/demo.js
+++ b/app/dictated-note-demo/demo.js
@@ -1,4 +1,5 @@
 // Dictated note demo implementation
+import { BufferedAudioStream } from '../shared/bufferAudioStream.js';
 import { getOrRefetchUserAccessToken, CORE_API_BASE_URL } from '../shared/authentication.js';
 import {
     disableElementById,
@@ -11,7 +12,7 @@ import {
 } from '../shared/commonUtils.js';
 
 let websocket;
-let dictateSeqId = 0;
+let bufferAudioStream;
 
 // Dictation handling
 const insertDictatedItem = (data) => {
@@ -41,7 +42,7 @@ const initializeDictationConnection = async () => {
             const data = JSON.parse(mes.data);
 
             if (data.type === "AUDIO_CHUNK_ACK") {
-                // This is where you'd remove audio chunks from your buffer
+                bufferAudioStream.handlePacketAck(data);
             } else if (data.type === "DICTATED_TEXT") {
                 insertDictatedItem(data);
             } else if (data.type === "ERROR_MESSAGE") {
@@ -64,7 +65,6 @@ const startDictating = async () => {
     disableElementById("dictate-btn");
     enableElementById("pause-btn");
 
-    dictateSeqId = 0;
     await initializeDictationConnection();
 
     // Await websocket being open
@@ -79,27 +79,38 @@ const startDictating = async () => {
         throw new Error("Websocket did not open");
     }
 
-    if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
-        const pcmWorker = await initializeMediaStream((audioAsBase64String) => (JSON.stringify({
+    if (!navigator.mediaDevices?.getUserMedia) {
+        console.error("Microphone audio stream is not accessible on this browser");
+        return;
+    }
+
+    bufferAudioStream = new BufferedAudioStream({
+        serializeAudioPacket: (data) => JSON.stringify(data),
+        websocket,
+    });
+
+    let dictateSeqId = 0;
+
+    const pcmWorker = await initializeMediaStream((audioAsBase64String) => {
+        const audioPacket = {
             type: "AUDIO_CHUNK",
             payload: audioAsBase64String,
             seq_id: dictateSeqId++,
-        })), websocket);
-
-        const locale = getDictationLocale();
-        const config = {
-            type: "CONFIG",
-            encoding: "PCM_S16LE",
-            sample_rate: 16000,
-            dictation_locale: locale,
-            punctuation_mode: "EXPLICIT",
         };
-        websocket.send(JSON.stringify(config));
+        bufferAudioStream.sendAndBuffer(audioPacket);
+    });
 
-        pcmWorker.port.start();
-    } else {
-        console.error("Microphone audio stream is not accessible on this browser");
-    }
+    const locale = getDictationLocale();
+    const configPacket = {
+        type: "CONFIG",
+        encoding: "PCM_S16LE",
+        sample_rate: 16000,
+        dictation_locale: locale,
+        punctuation_mode: "EXPLICIT",
+    };
+    websocket.send(JSON.stringify(configPacket));
+
+    pcmWorker.port.start();
 };
 
 const pauseDictating = async () => {

--- a/app/shared/bufferAudioStream.js
+++ b/app/shared/bufferAudioStream.js
@@ -1,0 +1,81 @@
+/**
+ * The max number of packets sent to the server but not ACKed yet.
+ * 
+ * Note: The number of in-flight packets is limited to 10 seconds of audio. Since
+ * is configured to send 192 ms of audio per packet, the max number of in-flight 
+ * packets is 50.
+ */
+const MAX_IN_FLIGHT_PACKETS = 50;
+
+/**
+ * A class to buffer audio packets and send them to the server.
+ * 
+ * It is used to make data transfer more resilient to network issues: 
+ * https://docs.nabla.com/guides/best-practices/transcription-network-resilience
+ */
+export class BufferedAudioStream {
+    /** The websocket to send the packets to. */
+    #websocket;
+
+    /** The function to serialize the audio packet. */
+    #serializeAudioPacket;
+
+    /** The packets that are waiting to be sent. */
+    #bufferedPackets = [];
+
+    /** The packets that are being sent to the server but not acknowledged yet. */
+    #inflightPackets = [];
+
+    constructor({ serializeAudioPacket, websocket }) {
+        this.#websocket = websocket;
+        this.#serializeAudioPacket = serializeAudioPacket;
+
+        // If the socket is not open, wait for it and flush the buffer.
+        if (this.#websocket.readyState !== WebSocket.OPEN) {
+            this.#websocket.addEventListener("open", () => {
+                this.#sendBufferedPacketsIfNeeded();
+            });
+        }
+    }
+
+    /**
+     * Send a packet to the server or buffer to be sent later.
+     */
+    sendAndBuffer(data) {
+        this.#bufferedPackets.push(data);
+        this.#sendBufferedPacketsIfNeeded();
+    }
+
+    /**
+     * Handle the acknowledgement of a packet by the server and send the buffered packets if 
+     * needed.
+     */
+    handlePacketAck(data) {
+        this.#inflightPackets = this.#inflightPackets.filter(
+            packet => packet.seq_id <= data.seq_id
+        );
+        this.#sendBufferedPacketsIfNeeded();
+    }
+
+    #sendBufferedPacketsIfNeeded() {
+        // Do nothing if the socket is not open.
+        if (this.#websocket.readyState !== WebSocket.OPEN) {
+            return;
+        }
+        
+        // Send the buffered packets as long as there are less than the max number of 
+        // in-flight packets.
+        while (
+            this.#bufferedPackets.length > 0 &&
+            this.#inflightPackets.length < MAX_IN_FLIGHT_PACKETS
+        ) {
+            // Remove the packet from the buffered packets and add it to the inflight packets.
+            const packet = this.#bufferedPackets.shift();
+            this.#inflightPackets.push(packet);
+
+            // Serialize the packet and send it to the server.
+            const serializedPacket = this.#serializeAudioPacket(packet);
+            this.#websocket.send(serializedPacket);
+        }
+    }
+}

--- a/app/shared/commonUtils.js
+++ b/app/shared/commonUtils.js
@@ -60,7 +60,7 @@ const endConnection = async (websocket, endObject) => {
 };
 
 // Audio utilities
-const initializeMediaStream = async (buildAudioChunk, websocket) => {
+const initializeMediaStream = async (handleAudioChunk) => {
     // Ask authorization to access the microphone
     const mediaStream = await navigator.mediaDevices.getUserMedia({
         audio: {
@@ -80,17 +80,12 @@ const initializeMediaStream = async (buildAudioChunk, websocket) => {
     mediaSource.connect(pcmWorker);
 
     // pcm post on message
-    pcmWorker.port.onmessage = (msg) => {
-        const pcm16iSamples = msg.data;
+    pcmWorker.port.onmessage = ({ data }) => {
         const audioAsBase64String = btoa(
-            String.fromCodePoint(...new Uint8Array(pcm16iSamples.buffer)),
+            String.fromCodePoint(...new Uint8Array(data.buffer)),
         );
-        if (websocket.readyState !== websocket.OPEN) {
-            console.error("Websocket is no longer open");
-            return;
-        }
 
-        websocket.send(buildAudioChunk(audioAsBase64String));
+        handleAudioChunk(audioAsBase64String);
     };
 
     return pcmWorker;

--- a/app/shared/commonUtils.js
+++ b/app/shared/commonUtils.js
@@ -5,6 +5,7 @@
 const API_VERSION = "2025-05-21"
 
 let thinkingId;
+let pcmWorker;
 let audioContext;
 let mediaSource;
 
@@ -71,9 +72,11 @@ const initializeMediaStream = async (handleAudioChunk) => {
         },
         video: false,
     });
+ 
     audioContext = new AudioContext({ sampleRate: 16000 });
     await audioContext.audioWorklet.addModule("../shared/rawPcm16Processor.js");
-    const pcmWorker = new AudioWorkletNode(audioContext, "raw-pcm-16-worker", {
+
+    pcmWorker = new AudioWorkletNode(audioContext, "raw-pcm-16-worker", {
         outputChannelCount: [1],
     });
     mediaSource = audioContext.createMediaStreamSource(mediaStream);

--- a/app/shared/rawPcm16Processor.js
+++ b/app/shared/rawPcm16Processor.js
@@ -1,10 +1,10 @@
+// Nodes of the Web Audio API process the audio stream in frames of the length
 // of 128 samples. Cf https://www.w3.org/TR/webaudio/#rendering-loop
 // (and they call it a quantum, plural quanta)
 const quantumSize = 128;
 
 // Number of quanta per packet we will send to the speech to text.
-// Typical recommendation is to send a packet every 100ms
-const quantaPerPacket = 24; // (1/32 kHz) * 128 * 24 = 96 ms
+const quantaPerPacket = 24; // (1/16 kHz) * 128 * 24 = 192 ms
 
 export class RawPCM16Processor extends AudioWorkletProcessor {
     constructor() {


### PR DESCRIPTION
This PR adds buffering capabilities to be more resilient with network interruptions. To make the code as readable as possible, the buffering is done through 2 queues: `bufferedPackets` and `inflightPackets`. 

**Note:** The demo doesn't handle automatic socket reconnection if the server returns a `COPILOT_AUDIO_STREAM_IDLE_TIMEOUT` after 10 seconds of network inactivity.  


https://github.com/user-attachments/assets/b32ccc7d-dcef-4a37-9179-8d1e6368dc1e


---- 

Fixes: https://github.com/nabla/health/issues/35938