### PR TITLE
feat: Add ASYNC_CORRECTION support for dictate-ws (API-431)

### DIFF
--- a/backend/src/version.ts
+++ b/backend/src/version.ts
@@ -1,1 +1,1 @@
-export const API_VERSION = '2026-06-12';
+export const API_VERSION = '2026-07-01';

--- a/frontend/src/api/dictate.ts
+++ b/frontend/src/api/dictate.ts
@@ -16,9 +16,16 @@ export interface AudioChunkAck {
   ack_id: number;
 }
 
+export interface AsyncCorrection {
+  type: "ASYNC_CORRECTION";
+  suffix: string;
+  replacement: string;
+}
+
 export type DictateServerMessage =
   | DictatedText
   | AudioChunkAck
+  | AsyncCorrection
   | { type: string };
 
 export const DICTATE_ENCODING = "PCM_S16LE" as const;
@@ -51,6 +58,8 @@ export function buildDictateConfig(locale: DictationLocale, noteText: string) {
       selection_start: noteText.length,
       selection_length: 0,
     },
+    // Opts into server-side refinements of already-streamed text via ASYNC_CORRECTION.
+    enable_async_corrections: true,
   };
 }
 

--- a/frontend/src/api/version.ts
+++ b/frontend/src/api/version.ts
@@ -1,1 +1,1 @@
-export const API_VERSION = "2026-06-12";
+export const API_VERSION = "2026-07-01";

--- a/frontend/src/pages/in-depth/dictate/dictate.render.ts
+++ b/frontend/src/pages/in-depth/dictate/dictate.render.ts
@@ -33,11 +33,23 @@ export function getNoteText(): string {
 }
 
 // dictate-ws emits DICTATED_TEXT segments that must be appended verbatim — no extra
-// spaces, punctuation, or formatting (the server already handles those).
+// spaces, punctuation, or formatting (the server already handles those). The server
+// may later refine trailing text via ASYNC_CORRECTION (see applyDictationCorrection).
 export function appendDictatedText(text: string): void {
   const note = document.getElementById("dictation-note") as HTMLTextAreaElement;
   note.value += text;
   note.scrollTop = note.scrollHeight;
+}
+
+export function applyDictationCorrection(
+  suffix: string,
+  replacement: string,
+): void {
+  const note = document.getElementById("dictation-note") as HTMLTextAreaElement;
+  if (note.value.endsWith(suffix)) {
+    note.value = note.value.slice(0, -suffix.length) + replacement;
+    note.scrollTop = note.scrollHeight;
+  }
 }
 
 export function clearNote(): void {

--- a/frontend/src/pages/in-depth/dictate/dictate.ts
+++ b/frontend/src/pages/in-depth/dictate/dictate.ts
@@ -1,4 +1,5 @@
 import {
+  type AsyncCorrection,
   type AudioChunkAck,
   buildDictateAudioChunk,
   buildDictateConfig,
@@ -17,6 +18,7 @@ import clientSource from "../../../transport/client.ts?raw";
 import {
   addWsMessage,
   appendDictatedText,
+  applyDictationCorrection,
   clearNote,
   getNoteText,
   readLocaleSelection,
@@ -58,7 +60,7 @@ const CODE_SNIPPETS = [
     region: "dictate-messages",
   },
   {
-    title: "5. Receive DICTATED_TEXT & append verbatim",
+    title: "5. Receive DICTATED_TEXT & apply async corrections",
     file: "pages/in-depth/dictate/dictate.ts",
     source: dictatePageSource,
     region: "dictate-receive",
@@ -224,6 +226,9 @@ function attachSocketHandlers(): void {
     addWsMessage("recv", event.data);
     if (message.type === "DICTATED_TEXT") {
       appendDictatedText((message as DictatedText).text);
+    } else if (message.type === "ASYNC_CORRECTION") {
+      const { suffix, replacement } = message as AsyncCorrection;
+      applyDictationCorrection(suffix, replacement);
     } else if (message.type === "AUDIO_CHUNK_ACK") {
       handleAck((message as AudioChunkAck).ack_id);
     }


### PR DESCRIPTION
## Summary

- Opt into `enable_async_corrections` on the dictate-ws `CONFIG` frame and add the `AsyncCorrection` server message type.
- Handle `ASYNC_CORRECTION` in the dictate page by replacing the trailing `suffix` of the note with `replacement`.
- Bump `API_VERSION` to `2026-07-01` in both frontend and backend.

Closes API-431.

## Test plan

- [x] Open the Dictate page and start a session — confirm `CONFIG` includes `"enable_async_corrections": true` in the WS log.
- [x] Dictate a phrase that triggers a correction — `DICTATED_TEXT` segments append, then `ASYNC_CORRECTION` updates the trailing note text in place.
- [x] Pause, clear, and resume dictation — existing flows still work.
- [x] CI passes (`tsc` + `vite build`).


Made with [Cursor](https://cursor.com)