### PR TITLE
feat: Replace sync normalized-data with async flow (API-432)

### DIFF
--- a/frontend/src/api/async-job.ts
+++ b/frontend/src/api/async-job.ts
@@ -1,0 +1,33 @@
+export type AsyncJobStatus = "ONGOING" | "SUCCEEDED" | "FAILED";
+
+export interface AsyncJob<TPayload = unknown> {
+  id: string;
+  status: AsyncJobStatus;
+  payload?: TPayload;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+
+export async function pollUntilSucceeded<TPayload>(
+  fetchJob: () => Promise<AsyncJob<TPayload>>,
+  options: { intervalMs?: number } = {},
+): Promise<TPayload> {
+  const intervalMs = options.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+  while (true) {
+    const job = await fetchJob();
+
+    if (job.status === "SUCCEEDED") {
+      if (job.payload === undefined) {
+        throw new Error("Async job succeeded but returned no payload.");
+      }
+      return job.payload;
+    }
+
+    if (job.status === "FAILED") {
+      throw new Error(`Async job ${job.id} failed.`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}

--- a/frontend/src/api/async-job.ts
+++ b/frontend/src/api/async-job.ts
@@ -6,15 +6,24 @@ export interface AsyncJob<TPayload = unknown> {
   payload?: TPayload;
 }
 
-const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_POLL_INTERVAL_MS = 10 * 1_000;
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1_000;
 
 export async function pollUntilSucceeded<TPayload>(
   fetchJob: () => Promise<AsyncJob<TPayload>>,
-  options: { intervalMs?: number } = {},
+  options: { intervalMs?: number; timeoutMs?: number } = {},
 ): Promise<TPayload> {
   const intervalMs = options.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
 
   while (true) {
+    await sleep(intervalMs);
+
+    if (Date.now() >= deadline) {
+      throw new Error(`Did not get results within ${timeoutMs}ms. Aborting polling.`);
+    }
+
     const job = await fetchJob();
 
     if (job.status === "SUCCEEDED") {
@@ -27,7 +36,9 @@ export async function pollUntilSucceeded<TPayload>(
     if (job.status === "FAILED") {
       throw new Error(`Async job ${job.id} failed.`);
     }
-
-    await new Promise((resolve) => setTimeout(resolve, intervalMs));
   }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/frontend/src/api/normalize.ts
+++ b/frontend/src/api/normalize.ts
@@ -1,3 +1,4 @@
+import { type AsyncJob, pollUntilSucceeded } from "./async-job.js";
 import { nablaFetch } from "../transport/client.js";
 import type { ClinicalNote } from "./note.js";
 
@@ -18,11 +19,18 @@ export interface NormalizedData {
 export async function generateNormalizedData(
   note: ClinicalNote,
 ): Promise<NormalizedData> {
-  const response = await nablaFetch("/v1/core/user/generate-normalized-data", {
-    method: "POST",
-    body: JSON.stringify({
-      note,
-    }),
-  });
-  return response.json() as Promise<NormalizedData>;
+  const submitResponse = await nablaFetch(
+    "/v1/core/user/generate-normalized-data-async",
+    {
+      method: "POST",
+      body: JSON.stringify({ note }),
+    },
+  );
+  const { id } = (await submitResponse.json()) as AsyncJob;
+
+  return pollUntilSucceeded<NormalizedData>(() =>
+    nablaFetch(`/v1/core/user/generate-normalized-data-async/${id}`).then(
+      (response) => response.json() as Promise<AsyncJob<NormalizedData>>,
+    ),
+  );
 }

--- a/frontend/src/pages/full-encounter-demo/work-on-note.render.ts
+++ b/frontend/src/pages/full-encounter-demo/work-on-note.render.ts
@@ -66,7 +66,7 @@ export function markup(): string {
         <div class="bg-white rounded-xl border border-grey-200 p-5">
           <div class="flex items-center gap-2 mb-1">
             <h3 class="font-semibold text-grey-400">Normalize Data</h3>
-            <a href="${DOCUMENTATION_LINKS.generateNormalizedData}" target="_blank" rel="noopener" class="text-xs font-mono text-grey-250 hover:text-primary-600 bg-grey-100 hover:bg-primary-50 px-2 py-0.5 rounded transition-colors">POST /generate-normalized-data ↗</a>
+            <a href="${DOCUMENTATION_LINKS.generateNormalizedData}" target="_blank" rel="noopener" class="text-xs font-mono text-grey-250 hover:text-primary-600 bg-grey-100 hover:bg-primary-50 px-2 py-0.5 rounded transition-colors">POST /generate-normalized-data-async ↗</a>
           </div>
           <p class="text-xs text-grey-300 mb-4">Extract ICD-10 / LOINC codes in FHIR format from the note.</p>
           <button id="generate-normalized-btn" disabled class="bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed">

--- a/frontend/src/shared/documentationLinks.ts
+++ b/frontend/src/shared/documentationLinks.ts
@@ -3,6 +3,7 @@
 export const DOCUMENTATION_LINKS = {
   transcribeWs: "https://docs.nabla.com/user/transcribe-ws",
   generateNote: "https://docs.nabla.com/user/generate-note",
-  generateNormalizedData: "https://docs.nabla.com/user/generate-normalized-data",
+  generateNormalizedData:
+    "https://docs.nabla.com/user/generate-normalized-data-async",
   generatePatientInstructions: "https://docs.nabla.com/user/generate-patient-instructions",
 } as const;


### PR DESCRIPTION
Showcase the recommended integration pattern for generate-normalized-data-async with a shared pollUntilSucceeded helper: poll after 10 seconds, stop after 5 minutes